### PR TITLE
Add DigitalOcean do-agent to base role.

### DIFF
--- a/roles/base/tasks/digital_ocean.yml
+++ b/roles/base/tasks/digital_ocean.yml
@@ -1,0 +1,39 @@
+---
+- name: Add DigitalOcean do-agent RPM GPG key (RHEL)
+  rpm_key:
+    state: present
+    key: "https://repos.sonar.digitalocean.com/sonar-agent.asc"
+  when: ansible_os_family == "RedHat"
+
+- name: Install DigitalOcean do-agent repo (RHEL)
+  yum_repository:
+    name: "digitalocean-agent"
+    file: "DigitalOcean-Sonar"
+    description: "DigitalOcean agent"
+    baseurl: "https://repos.sonar.digitalocean.com/yum/$basearch"
+    gpgcheck: yes
+    gpgkey: "https://repos.sonar.digitalocean.com/sonar-agent.asc"
+  when: ansible_os_family == "RedHat"
+
+- name: Add DigitalOcean do-agent APT GPG key (Ubuntu)
+  apt_key:
+    state: present
+    url: "https://repos.sonar.digitalocean.com/sonar-agent.asc"
+  when: ansible_os_family == "Debian"
+
+- name: Install DigitalOcean do-agent repo (Ubuntu)
+  apt_repository:
+    repo: "deb https://repos.sonar.digitalocean.com/apt main main"
+    state: present
+  when: ansible_os_family == "Debian"
+
+- name: Install DigitalOcean do-agent
+  package: 
+    name: "do-agent"
+    update_cache: yes
+
+- name: Start DigitalOcean do-agent
+  service: 
+    name: do-agent
+    state: started
+    enabled: yes

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -1,6 +1,10 @@
 ---
+- name: Run AWS specific tasks
+  include_tasks: aws.yml
+  when: (ansible_product_uuid | search("^EC2") and ansible_system_vendor == "Xen")
+
 - name: Run DigitalOcean specific tasks
-  include: digital_ocean.yml
+  include_tasks: digital_ocean.yml
   when: ansible_system_vendor == "DigitalOcean"
 
 - name: Upgrade all packages (RHEL)

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Run DigitalOcean specific tasks
+  include: digital_ocean.yml
+  when: ansible_system_vendor == "DigitalOcean"
+
 - name: Upgrade all packages (RHEL)
   yum: 
     name: "*"


### PR DESCRIPTION
DigitalOcean offers an agent which can be used to collection additional OS metrics. Adding a task to (conditionally) install this agent.