### PR TITLE
Update redirects in nginx template

### DIFF
--- a/roles/web/templates/default.conf.j2
+++ b/roles/web/templates/default.conf.j2
@@ -6,8 +6,8 @@ upstream uwsgicluster {
 
 server {
     listen       80;
-    server_name  {{inventory_hostname}} www.{{inventory_hostname}};
-    return       301 https://{{inventory_hostname}}$request_uri;
+    server_name  {{inventory_hostname}};
+    return       301 https://$host$request_uri;
 }
 
 
@@ -44,12 +44,12 @@ server {
 server {
     listen       80;
     server_name  theoval.us www.theoval.us;
-    return       301 https://theoval.us$request_uri;
+    return       301 https://$host$request_uri;
 }
 
 server {
     listen       443 ssl;
-    server_name  theoval.us;
+    server_name  theoval.us www.theoval.us;
     add_header Strict-Transport-Security "max-age=31536000; 
     includeSubDomains";
     ssl_certificate /etc/nginx/ssl/theoval.us_cert.pem;


### PR DESCRIPTION
http to https redirects are broken in recent versions of Chrome due to some strict HSTS checking.
Fixes #6